### PR TITLE
switch to HTTPS site

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://plugins.roundcube.net"
+            "url": "https://plugins.roundcube.net"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "roundcube-plugin",
     "description": "A plugin to use Yubico's Yubikey 2nd factor with Roundcube webmail.",
     "keywords": ["password","security","yubico","yubikey","authentication","factor", "OTP", "token", "login"],
-    "homepage": "http://github.com/northox/roundcube-yubikey-plugin",
+    "homepage": "https://github.com/northox/roundcube-yubikey-plugin",
     "license": "GPL2",
     "authors": [
         {


### PR DESCRIPTION
Composer now throws an error if packages have to be downloaded via HTTP instead of HTTPS.
This pull request changes the github URL from HTTP to HTTPS.