### PR TITLE
Fixes PHP methods can't be named as their class error

### DIFF
--- a/lib/Yubico.php
+++ b/lib/Yubico.php
@@ -98,7 +98,7 @@ class Auth_Yubico
 	 *                                 default true)
 	 * @access public
 	 */
-	function Auth_Yubico($id, $key = '', $https = 0, $httpsverify = 1)
+	function __construct($id, $key = '', $https = 0, $httpsverify = 1)
 	{
 		$this->_id =  $id;
 		$this->_key = base64_decode($key);


### PR DESCRIPTION
Fixes error `PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; Auth_Yubico has a deprecated constructor in /usr/share/webapps/roundcubemail/plugins/yubikey_authentication/lib/Yubico.php on line 29`